### PR TITLE
fix compilation error with hashable-1.2.5.0

### DIFF
--- a/src/Data/Hashable/Extras.hs
+++ b/src/Data/Hashable/Extras.hs
@@ -23,7 +23,7 @@ module Data.Hashable.Extras
 
 import Data.Bifunctor
 import Data.Functor.Identity
-import Data.Hashable
+import Data.Hashable hiding (Hashed, unhashed)
 
 data Hashed = Hashed { unhashed :: Int -> Int }
 


### PR DESCRIPTION
This PR fixes the following compilation error with hashable-1.2.5.0

```
hashable-extras/src/Data/Hashable/Extras.hs:30:19: error:
    Ambiguous occurrence ‘Hashed’
    It could refer to either ‘Data.Hashable.Hashed’,
                             imported from ‘Data.Hashable’ at src/Data/Hashable/Extras.hs:26:1-20
                             (and originally defined in ‘hashable-1.2.5.0:Data.Hashable.Class’)
                          or ‘Data.Hashable.Extras.Hashed’,
                             defined at src/Data/Hashable/Extras.hs:28:1

hashable-extras/src/Data/Hashable/Extras.hs:31:22: error:
    Ambiguous occurrence ‘unhashed’
    It could refer to either ‘Data.Hashable.unhashed’,
                             imported from ‘Data.Hashable’ at src/Data/Hashable/Extras.hs:26:1-20
                             (and originally defined in ‘hashable-1.2.5.0:Data.Hashable.Class’)
                          or ‘Data.Hashable.Extras.unhashed’,
                             defined at src/Data/Hashable/Extras.hs:28:24
```